### PR TITLE
space-travelers - add logic to reserve mission

### DIFF
--- a/src/components/MissionCard.js
+++ b/src/components/MissionCard.js
@@ -2,17 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import './MissionCard.css';
 
-const MissionCard = ({ mission }) => (
+const MissionCard = ({ mission, joinTheMission }) => (
   <>
     <tbody>
-      <tr>
+      <tr data-id={mission.mission_id}>
         <td className="mission-title">{mission.mission_name}</td>
         <td className="mission-desc">{mission.description}</td>
         <td className="join-mission">
-          <span className="me-3 span-top">Active Member</span>
+          <button type="button" className="me-3 span-top">Active Member</button>
         </td>
         <td className="member-status">
-          <span className="span-down">Join Mission</span>
+          <button type="button" className="span-down" onClick={joinTheMission}>Join Mission</button>
         </td>
       </tr>
     </tbody>
@@ -21,6 +21,7 @@ const MissionCard = ({ mission }) => (
 
 MissionCard.propTypes = {
   mission: PropTypes.node.isRequired,
+  joinTheMission: PropTypes.node.isRequired,
 };
 
 export default MissionCard;

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -2,12 +2,18 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import MissionCard from './MissionCard';
-import { fetchMission } from '../redux/mission/mission';
+import { fetchMission, reserveMission } from '../redux/mission/mission';
 import './Missions.css';
 
 const Mission = () => {
   const dispatch = useDispatch();
   const mission = useSelector((state) => state.missions);
+
+  const joinTheMission = (e) => {
+    const mission = e.target.parentNode.parentNode;
+    const missionId = mission.getAttribute('data-id');
+    dispatch(reserveMission(missionId));
+  };
 
   useEffect(() => {
     dispatch(fetchMission());
@@ -21,7 +27,7 @@ const Mission = () => {
           <th>Status</th>
         </tr>
       </thead>
-      {mission && mission.map((mission) => <MissionCard mission={mission} key={mission.mission_id} />)}
+      {mission && mission.map((mission) => <MissionCard mission={mission} key={mission.mission_id} joinTheMission={joinTheMission} />)}
     </table>
   );
 };

--- a/src/redux/mission/mission.js
+++ b/src/redux/mission/mission.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-case-declarations */
 // import _ from 'lodash';
 import axios from 'axios';
 
@@ -5,7 +6,13 @@ const initialState = [];
 
 const FETCH_MISSION_SUCCESS = 'space-travelers/mission/FETCH_MISSION_SUCCESS';
 const FETCH_MISSION_FAILURE = 'space-travelers/mission/FETCH_MISSION_FAILURE';
+const RESERVE_MISSION = 'space-travelers/mission/RESERVE_MISSION';
 const URL = 'https://api.spacexdata.com/v3/missions';
+
+export const reserveMission = (payload) => ({
+  type: RESERVE_MISSION,
+  payload,
+});
 
 export const fetchMissionSuccess = (payload) => ({
   type: FETCH_MISSION_SUCCESS,
@@ -32,6 +39,14 @@ const missionReducer = (state = initialState, { type, payload }) => {
       return payload;
     case FETCH_MISSION_FAILURE:
       return state;
+    case RESERVE_MISSION:
+      const newState = state.map((mission) => {
+        if (mission.mission_id !== payload) {
+          return mission;
+        }
+        return { ...mission, reserved: true };
+      });
+      return newState;
     default:
       return state;
   }


### PR DESCRIPTION
### In this pull request:

- When a user clicks the "Join Mission" button, an action is dispatched to update the store. 
- I get the ID of the selected mission and update the state. 
- I return a new state object with all missions, but the selected mission will have an extra key reserved with its value set to true